### PR TITLE
build(CMakeLists): fix CMake warning

### DIFF
--- a/dialogs/CMakeLists.txt
+++ b/dialogs/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # ---------------------------------------------------------
 
-find_package(Qt5Widgets)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -44,7 +44,7 @@ set_target_properties(QtFindReplaceDialog PROPERTIES PUBLIC_HEADER "${QtFindRepl
 target_compile_definitions(QtFindReplaceDialog PUBLIC "-DFINDREPLACESHARED_EXPORT=")
 target_compile_definitions(QtFindReplaceDialog PRIVATE "-DFINDREPLACE_LIBRARY")
 target_compile_options(QtFindReplaceDialog PUBLIC ${MY_COMPILE_OPTIONS})
-qt5_use_modules(QtFindReplaceDialog Core Widgets)
+target_link_libraries(QtFindReplaceDialog PRIVATE Qt5::Widgets)
 
 target_include_directories(QtFindReplaceDialog SYSTEM INTERFACE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
This fixes this warning:

```
CMake Warning (dev) at /usr/lib64/cmake/Qt5Core/Qt5CoreMacros.cmake:44 (message):
  qt5_use_modules is not part of the official API, and might be removed in Qt
  6.
Call Stack (most recent call first):
  /usr/lib64/cmake/Qt5Core/Qt5CoreMacros.cmake:431 (_qt5_warn_deprecated)
  third_party/QtFindReplaceDialog/dialogs/CMakeLists.txt:47 (qt5_use_modules)
This warning is for project developers.  Use -Wno-dev to suppress it.
```