### PR TITLE
feat: keep undo history when setting text-to-find

### DIFF
--- a/dialogs/findreplaceform.cpp
+++ b/dialogs/findreplaceform.cpp
@@ -158,7 +158,8 @@ void FindReplaceForm::showMessage(const QString &message)
 
 void FindReplaceForm::setTextToFind(const QString &strText)
 {
-    ui->textToFind->setText(strText);
+    ui->textToFind->selectAll();
+    ui->textToFind->insert(strText);
 }
 
 void FindReplaceForm::find()


### PR DESCRIPTION
Don't clear undo history when `FindReplaceForm::setTextToFind` is called. This is helpful if the user accidentally opens the Find/Replace dialog with some text selected in the code editor and loses the text-to-find.