### PR TITLE
refactor: use Q_SLOTS macro to boost signals compatibility

### DIFF
--- a/dialogs/findreplacedialog.h
+++ b/dialogs/findreplacedialog.h
@@ -50,7 +50,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceDialog : public QDialog
      */
     virtual void readSettings(QSettings &settings, const QString &prefix = "FindReplaceDialog");
 
-  public slots:
+  public Q_SLOTS:
     /**
      * Sets the current textToFind (used to set it from specialized current selection, etc)
      */

--- a/dialogs/findreplaceform.h
+++ b/dialogs/findreplaceform.h
@@ -80,7 +80,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
      */
     virtual void readSettings(QSettings &settings, const QString &prefix = "FindReplaceDialog");
 
-  public slots:
+  public Q_SLOTS:
     /**
      * Sets the current textToFind (used to set it from specialized current selection, etc)
      */
@@ -139,7 +139,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
     /// shows a message in the dialog
     void showMessage(const QString &message);
 
-  protected slots:
+  protected Q_SLOTS:
     /// when the text edit contents changed
     void textToFindChanged();
 

--- a/examples/mainwindow.h
+++ b/examples/mainwindow.h
@@ -30,7 +30,7 @@ protected:
     void writeSettings();
     void readSettings();
 
-private slots:
+private Q_SLOTS:
     void about();
 
     void findDialog();


### PR DESCRIPTION
Use Q_SLOTS for boost signals compatibility. This will also help when QT_NO_KEYWORDS is defined.