### PR TITLE
Merge qplaintextedit branch into master

### DIFF
--- a/dialogs/CMakeLists.txt
+++ b/dialogs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/dialogs/CMakeLists.txt
+++ b/dialogs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/dialogs/CMakeLists.txt
+++ b/dialogs/CMakeLists.txt
@@ -1,11 +1,13 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.12)
+project(QtFindReplaceDialog LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # ---------------------------------------------------------
 
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -44,7 +46,7 @@ set_target_properties(QtFindReplaceDialog PROPERTIES PUBLIC_HEADER "${QtFindRepl
 target_compile_definitions(QtFindReplaceDialog PUBLIC "-DFINDREPLACESHARED_EXPORT=")
 target_compile_definitions(QtFindReplaceDialog PRIVATE "-DFINDREPLACE_LIBRARY")
 target_compile_options(QtFindReplaceDialog PUBLIC ${MY_COMPILE_OPTIONS})
-target_link_libraries(QtFindReplaceDialog PRIVATE Qt5::Widgets)
+target_link_libraries(QtFindReplaceDialog PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Core)
 
 target_include_directories(QtFindReplaceDialog SYSTEM INTERFACE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/dialogs/findform.cpp
+++ b/dialogs/findform.cpp
@@ -3,28 +3,27 @@
  * See COPYING file that comes with this distribution
  */
 
-#include <QtGui>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QRegExp>
+#include <QtGui>
 
 #include "findform.h"
 #include "ui_findreplaceform.h"
 
-FindForm::FindForm(QWidget *parent) :
-    FindReplaceForm(parent)
+FindForm::FindForm(QWidget *parent) : FindReplaceForm(parent)
 {
     hideReplaceWidgets();
 }
 
 FindForm::~FindForm()
 {
-
 }
 
 void FindForm::changeEvent(QEvent *e)
 {
     QWidget::changeEvent(e);
-    switch (e->type()) {
+    switch (e->type())
+    {
     case QEvent::LanguageChange:
         ui->retranslateUi(this);
         break;
@@ -33,11 +32,12 @@ void FindForm::changeEvent(QEvent *e)
     }
 }
 
-void FindForm::writeSettings(QSettings &settings, const QString &prefix) {
+void FindForm::writeSettings(QSettings &settings, const QString &prefix)
+{
     FindReplaceForm::writeSettings(settings, prefix);
 }
 
-void FindForm::readSettings(QSettings &settings, const QString &prefix) {
+void FindForm::readSettings(QSettings &settings, const QString &prefix)
+{
     FindReplaceForm::readSettings(settings, prefix);
 }
-

--- a/dialogs/findform.cpp
+++ b/dialogs/findform.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <QPlainTextEdit>
-#include <QRegExp>
 #include <QtGui>
 
 #include "findform.h"

--- a/dialogs/findreplacedialog.cpp
+++ b/dialogs/findreplacedialog.cpp
@@ -30,7 +30,7 @@ void FindReplaceDialog::changeEvent(QEvent *e)
     }
 }
 
-void FindReplaceDialog::setTextEdit(QTextEdit *textEdit)
+void FindReplaceDialog::setTextEdit(QPlainTextEdit *textEdit)
 {
     ui->findReplaceForm->setTextEdit(textEdit);
 }

--- a/dialogs/findreplacedialog.h
+++ b/dialogs/findreplacedialog.h
@@ -15,7 +15,7 @@ namespace Ui
 class FindReplaceDialog;
 }
 
-class QTextEdit;
+class QPlainTextEdit;
 class QSettings;
 
 /**
@@ -34,7 +34,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceDialog : public QDialog
      * Associates the text editor where to perform the search
      * @param textEdit
      */
-    void setTextEdit(QTextEdit *textEdit);
+    void setTextEdit(QPlainTextEdit *textEdit);
 
     /**
      * Writes the state of the form to the passed settings.

--- a/dialogs/findreplacedialog.h
+++ b/dialogs/findreplacedialog.h
@@ -50,7 +50,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceDialog : public QDialog
      */
     virtual void readSettings(QSettings &settings, const QString &prefix = "FindReplaceDialog");
 
-  public slots:
+  public Q_SLOTS:
     /**
      * Sets the current textToFind (used to set it from specialized current selection, etc)
      */

--- a/dialogs/findreplaceform.cpp
+++ b/dialogs/findreplaceform.cpp
@@ -3,10 +3,10 @@
  * See COPYING file that comes with this distribution
  */
 
+#include <QPlainTextEdit>
 #include <QRegExp>
 #include <QSettings>
 #include <QShowEvent>
-#include <QTextEdit>
 #include <QtGui>
 
 #include "findreplaceform.h"
@@ -59,7 +59,7 @@ void FindReplaceForm::hideReplaceWidgets()
     ui->replaceAllButton->setVisible(false);
 }
 
-void FindReplaceForm::setTextEdit(QTextEdit *textEdit_)
+void FindReplaceForm::setTextEdit(QPlainTextEdit *textEdit_)
 {
     if (textEdit != textEdit_)
     {

--- a/dialogs/findreplaceform.cpp
+++ b/dialogs/findreplaceform.cpp
@@ -287,11 +287,13 @@ void FindReplaceForm::replaceAll()
 
     int cnt = 0;
     find();
+    textEdit->textCursor().beginEditBlock();
     while (ui->replaceButton->isEnabled())
     {
         replace();
         ++cnt;
-    };
+    }
+    textEdit->textCursor().endEditBlock();
 
     showMessage(tr("Replaced %1 occurrence(s)", "FindDialog").arg(cnt));
 }

--- a/dialogs/findreplaceform.cpp
+++ b/dialogs/findreplaceform.cpp
@@ -4,7 +4,11 @@
  */
 
 #include <QPlainTextEdit>
+#if QT_VERSION >= 0x050000
+#include <QRegularExpression>
+#else
 #include <QRegExp>
+#endif
 #include <QSettings>
 #include <QShowEvent>
 #include <QtGui>
@@ -119,8 +123,12 @@ void FindReplaceForm::validateRegExp(const QString &text)
         ui->errorLabel->setText("");
         return; // nothing to validate
     }
-
+#if QT_VERSION >= 0x050000
+    QRegularExpression reg(text,
+                (ui->caseCheckBox->isChecked() ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption));
+#else
     QRegExp reg(text, (ui->caseCheckBox->isChecked() ? Qt::CaseSensitive : Qt::CaseInsensitive));
+#endif
 
     if (reg.isValid())
     {
@@ -208,7 +216,12 @@ void FindReplaceForm::find(bool next)
 
     if (ui->regexCheckBox->isChecked())
     {
+#if QT_VERSION >= 0x050500			// Needs to be >=5.5 since QTextDocument::find QRegularExpression is in >=5.5 below
+        QRegularExpression reg(toSearch,
+                    (ui->caseCheckBox->isChecked() ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption));
+#else
         QRegExp reg(toSearch, (ui->caseCheckBox->isChecked() ? Qt::CaseSensitive : Qt::CaseInsensitive));
+#endif
 
 #if (DEBUG_FIND)
         qDebug() << "searching for regexp: " << reg.pattern();

--- a/dialogs/findreplaceform.h
+++ b/dialogs/findreplaceform.h
@@ -16,18 +16,18 @@ namespace Ui
 class FindReplaceForm;
 }
 
-class QTextEdit;
+class QPlainTextEdit;
 class QSettings;
 class QEvent;
 class QShowEvent;
 
 /**
  * The form for the find/replace dialog.  The form presents the typical
- * widgets you find in standard find/replace dialogs, and it acts on a QTextEdit.
+ * widgets you find in standard find/replace dialogs, and it acts on a QPlainTextEdit.
  *
  * \image html Screenshot-FindReplace.png
  *
- * You need to set the QTextEdit explicitly, using the method setTextEdit(QTextEdit *textEdit).
+ * You need to set the QPlainTextEdit explicitly, using the method setTextEdit(QPlainTextEdit *textEdit).
  *
  * For instance
  * \code
@@ -61,7 +61,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
      * Associates the text editor where to perform the search
      * @param textEdit_
      */
-    void setTextEdit(QTextEdit *textEdit_);
+    void setTextEdit(QPlainTextEdit *textEdit_);
 
     /// hides replace widgets from the form
     void hideReplaceWidgets();
@@ -159,7 +159,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
     QTextCursor textCursor;
 
     /// the text editor (possibly) associated with this form
-    QTextEdit *textEdit;
+    QPlainTextEdit *textEdit;
 
     // connection to textedit selection change
     QMetaObject::Connection selectionChangeConnection;

--- a/dialogs/findreplaceform.h
+++ b/dialogs/findreplaceform.h
@@ -80,7 +80,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
      */
     virtual void readSettings(QSettings &settings, const QString &prefix = "FindReplaceDialog");
 
-  public slots:
+  public Q_SLOTS:
     /**
      * Sets the current textToFind (used to set it from specialized current selection, etc)
      */
@@ -88,10 +88,10 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
 
     /**
      * performs the find task
-     * @param down whether to find the next or the previous
+     * @param next whether to find the next or the previous
      * occurrence
      */
-    void find(bool down);
+    void find(bool next);
 
     /**
      * Finds the next occurrence
@@ -139,7 +139,7 @@ class FINDREPLACESHARED_EXPORT FindReplaceForm : public QWidget
     /// shows a message in the dialog
     void showMessage(const QString &message);
 
-  protected slots:
+  protected Q_SLOTS:
     /// when the text edit contents changed
     void textToFindChanged();
 

--- a/examples/mainwindow.h
+++ b/examples/mainwindow.h
@@ -30,7 +30,7 @@ protected:
     void writeSettings();
     void readSettings();
 
-private slots:
+private Q_SLOTS:
     void about();
 
     void findDialog();

--- a/examples/mainwindow.ui
+++ b/examples/mainwindow.ui
@@ -16,7 +16,7 @@
   <widget class="QWidget" name="centralWidget">
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="0">
-     <widget class="QTextEdit" name="textEdit"/>
+     <widget class="QPlainTextEdit" name="textEdit"/>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
## Summary
- Merges the `qplaintextedit` branch into `master`, unifying all changes
- Brings in QPlainTextEdit refactor, Qt6 support (CMake + QRegExp→QRegularExpression), and cmake_minimum_required bump
- Resolves CMakeLists.txt conflict (took qplaintextedit's version range `3.5...3.12`)

After this merge, `master` will contain everything from both branches — no need to maintain them separately.